### PR TITLE
chore(ts): update strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "external/*"
       ],
       "dependencies": {
-        "@platformatic/composer": "^2.27.1",
-        "@platformatic/runtime": "^2.27.1",
-        "wattpm": "^2.27.1"
+        "@platformatic/composer": "^2.30.0",
+        "@platformatic/runtime": "^2.30.0",
+        "wattpm": "^2.30.0"
       }
     },
     "node_modules/@actions/core": {
@@ -9030,8 +9030,8 @@
     },
     "web/backend": {
       "dependencies": {
-        "@platformatic/control": "^2.27.1",
-        "@platformatic/service": "^2.27.1"
+        "@platformatic/control": "^2.30.0",
+        "@platformatic/service": "^2.30.0"
       },
       "devDependencies": {
         "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
@@ -9042,7 +9042,7 @@
     },
     "web/composer": {
       "dependencies": {
-        "@platformatic/composer": "^2.27.1"
+        "@platformatic/composer": "^2.30.0"
       },
       "devDependencies": {
         "borp": "^0.19.0",
@@ -9053,7 +9053,7 @@
     "web/frontend": {
       "version": "0.0.0",
       "dependencies": {
-        "@platformatic/vite": "^2.27.1",
+        "@platformatic/vite": "^2.30.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "wattpm start"
   },
   "dependencies": {
-    "@platformatic/composer": "^2.27.1",
-    "@platformatic/runtime": "^2.27.1",
-    "wattpm": "^2.27.1"
+    "@platformatic/composer": "^2.30.0",
+    "@platformatic/runtime": "^2.30.0",
+    "wattpm": "^2.30.0"
   },
   "workspaces": [
     "web/*",

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@platformatic/control": "^2.27.1",
-    "@platformatic/service": "^2.27.1"
+    "@platformatic/control": "^2.30.0",
+    "@platformatic/service": "^2.30.0"
   }
 }

--- a/web/backend/routes/root.ts
+++ b/web/backend/routes/root.ts
@@ -1,7 +1,6 @@
 /// <reference path="../global.d.ts" />
 import { FastifyInstance, FastifyPluginOptions } from 'fastify'
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
-// TODO: create types for RuntimeApiClient and re-enable strict mode
 import { RuntimeApiClient } from '@platformatic/control'
 
 declare module 'fastify' {
@@ -29,10 +28,9 @@ export default async function (fastify: FastifyInstance, opts: FastifyPluginOpti
   }, async (request, reply) => {
     let runtimes = await api.getRuntimes()
 
-    console.log(request.query.includeAdmin)
-
     if (!request.query.includeAdmin) {
-      runtimes = runtimes.filter((runtime) => runtime.packageName !== 'watt-admin')
+      // FIXME: remove `any` once the proper type is passed from `@platformatic/control`
+      runtimes = runtimes.filter((runtime: any) => runtime.packageName !== 'watt-admin')
     }
 
     return runtimes

--- a/web/backend/tsconfig.json
+++ b/web/backend/tsconfig.json
@@ -7,7 +7,7 @@
     "pretty": true,
     "noEmitOnError": true,
     "incremental": true,
-    "strict": false,
+    "strict": true,
     "outDir": "dist",
     "skipLibCheck": true
   },

--- a/web/composer/package.json
+++ b/web/composer/package.json
@@ -12,6 +12,6 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@platformatic/composer": "^2.27.1"
+    "@platformatic/composer": "^2.30.0"
   }
 }

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@platformatic/vite": "^2.27.1"
+    "@platformatic/vite": "^2.30.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",


### PR DESCRIPTION
Now that [this is released](https://github.com/platformatic/platformatic/pull/3741) with the new `@platformatic/control` version, we can finally enable `strict` mode. A follow-up PR with more proper types will follow on the `platformatic` repo.