### PR TITLE
chore(ci): update and add action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: run tests
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@releases/v4.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: npm ci
+        uses: nick-fields/retry@v3.0.0
+        with:
+          max_attempts: 10
+          timeout_minutes: 15
+          retry_on: error
+          command: npm ci
+      - name: Run build
+        run: npm run build
+      - name: Run backend tests
+        run: cd web/backend && npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "external/*"
       ],
       "dependencies": {
-        "@platformatic/composer": "^2.30.0",
-        "@platformatic/runtime": "^2.30.0",
-        "wattpm": "^2.30.0"
+        "@platformatic/composer": "^2.30.1",
+        "@platformatic/runtime": "^2.30.1",
+        "wattpm": "^2.30.1"
       }
     },
     "node_modules/@actions/core": {
@@ -2665,17 +2665,17 @@
       }
     },
     "node_modules/@platformatic/basic": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/basic/-/basic-2.30.0.tgz",
-      "integrity": "sha512-LxLaisKxowOAqu1YZ/nVUgcO6K5AI5Z1pBKn+lsnw23glrSax56UUqq5ye3QAqNbkrCj7gAPeeAMOT/AfvoNww==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/basic/-/basic-2.30.1.tgz",
+      "integrity": "sha512-05f9sWHZA4a9vrP6kS1NW71IiFMnZ9Rvib+hBsoigEmXmGegBcepvsVe+8VVKuULZi6bZp5vDl0JRlOhUC4/Mw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/error": "^4.0.0",
-        "@platformatic/config": "2.30.0",
-        "@platformatic/itc": "2.30.0",
-        "@platformatic/metrics": "2.30.0",
-        "@platformatic/telemetry": "2.30.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/config": "2.30.1",
+        "@platformatic/itc": "2.30.1",
+        "@platformatic/metrics": "2.30.1",
+        "@platformatic/telemetry": "2.30.1",
+        "@platformatic/utils": "2.30.1",
         "execa": "^9.3.1",
         "fast-json-patch": "^3.1.1",
         "pino": "^9.3.2",
@@ -2687,9 +2687,9 @@
       }
     },
     "node_modules/@platformatic/client": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/client/-/client-2.30.0.tgz",
-      "integrity": "sha512-xg3KrCBZ4zw9C/ukBAfoQHgWgPCRnT0UTn3vWMRbkM5+07Tj4jgTFHl5BjdAjF7LUDiCulKl9xjEEefjfZFiQg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/client/-/client-2.30.1.tgz",
+      "integrity": "sha512-oRQxQFKOgXQajxFRfwiaIx42I22D1TLnSRoqRH8kN3uqloyrYHB2CJHNrMWIesZDJSv/KkEbGLjV6IHfLSfhUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.5.4",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@platformatic/composer": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/composer/-/composer-2.30.0.tgz",
-      "integrity": "sha512-X+ZeaAtYe3uhcH5PvHCdpNteKJwTUcAxjoXfJ59XOO23Fyrh6GsT0+YZ3C3g/TLa/TSleywEs8cDyhSfvLipww==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/composer/-/composer-2.30.1.tgz",
+      "integrity": "sha512-TaQJuxLKuf2BytK7dwnqIM6lTziIO3JXVuyQWrpJaPAuE5MK3dGnoSIa73N7KAO9rIbsxtcAg25E7EeC1qgt1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/error": "^4.0.0",
@@ -2714,14 +2714,14 @@
         "@fastify/static": "^8.0.0",
         "@fastify/swagger": "^9.0.0",
         "@fastify/view": "^10.0.1",
-        "@platformatic/config": "2.30.0",
+        "@platformatic/config": "2.30.1",
         "@platformatic/fastify-openapi-glue": "^5.0.0",
-        "@platformatic/generators": "2.30.0",
+        "@platformatic/generators": "2.30.1",
         "@platformatic/graphql-composer": "^0.10.0",
-        "@platformatic/scalar-theme": "2.30.0",
-        "@platformatic/service": "2.30.0",
-        "@platformatic/telemetry": "2.30.0",
-        "@platformatic/utils": "^2.30.0",
+        "@platformatic/scalar-theme": "2.30.1",
+        "@platformatic/service": "2.30.1",
+        "@platformatic/telemetry": "2.30.1",
+        "@platformatic/utils": "^2.30.1",
         "@scalar/fastify-api-reference": "^1.19.5",
         "ajv": "^8.12.0",
         "commist": "^3.2.0",
@@ -2750,15 +2750,24 @@
         "plt-composer": "composer.mjs"
       }
     },
+    "node_modules/@platformatic/composer/node_modules/undici": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.1.1.tgz",
+      "integrity": "sha512-WZkQ6eH9f5ZT93gaIffsbUaDpBwjbpvmMbfaEhOnbdUneurTESeRxwPGwjI28mRFESH3W3e8Togijh37ptOQqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@platformatic/config": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/config/-/config-2.30.0.tgz",
-      "integrity": "sha512-S0iQasstpJNy84aT2FeGmhy7TC1tLncb6PIDtf8e3gY/pkGl5YekDUKtMxRqyWy9/l86NLMfEeNJW7+SYbhjJg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/config/-/config-2.30.1.tgz",
+      "integrity": "sha512-f7U7flULdqSai/9f/GDO5wFdz3ZqjX5xlPc7aDZktuSutGIZR8JD34erGig//aXlSJjTEfJILAEf+Z9zJFmqhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/deepmerge": "^2.0.0",
         "@fastify/error": "^4.0.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/utils": "2.30.1",
         "abstract-logging": "^2.0.1",
         "ajv": "^8.12.0",
         "dotenv": "^16.4.5",
@@ -2770,13 +2779,13 @@
       }
     },
     "node_modules/@platformatic/control": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/control/-/control-2.30.0.tgz",
-      "integrity": "sha512-69mPmXA6KwWhUY3M3rS5+mr9SA+QvpZsvab5GykDfNPdX+Ra40YO9GaoALZmoJDJ61tGo9coJJXiTRDGbfq9NA==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/control/-/control-2.30.1.tgz",
+      "integrity": "sha512-D3W99Vys1kC8WV51ymzbmhGd00P92z7UBxHeDXprERS6jg2yL33uvcApUrXcCarmaq6YuhizlMNbA//JDxZi1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/error": "^4.0.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/utils": "2.30.1",
         "commist": "^3.2.0",
         "help-me": "^5.0.0",
         "pino": "^9.0.0",
@@ -2787,6 +2796,15 @@
       },
       "bin": {
         "plt-ctl": "control.js"
+      }
+    },
+    "node_modules/@platformatic/control/node_modules/undici": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.1.1.tgz",
+      "integrity": "sha512-WZkQ6eH9f5ZT93gaIffsbUaDpBwjbpvmMbfaEhOnbdUneurTESeRxwPGwjI28mRFESH3W3e8Togijh37ptOQqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@platformatic/fastify-http-metrics": {
@@ -2817,17 +2835,26 @@
       }
     },
     "node_modules/@platformatic/generators": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/generators/-/generators-2.30.0.tgz",
-      "integrity": "sha512-pBPgZXNRgti//xFy9Ch3G5gVUK16aLjdbNzQOeAf13aLr/1a1LR35Sq3A7SecUvz+hrR+W8WQusD0ED/rYeUiQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/generators/-/generators-2.30.1.tgz",
+      "integrity": "sha512-tkGvU4qZF5+fB8Y7kyb6DIEqHVHxckz0uSIGaDpUOD4xWI+UzkVfDFyLVQzLoq+KTSCHCFGR8p/oma4DOOgUaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/error": "^4.0.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/utils": "2.30.1",
         "change-case-all": "^2.1.0",
         "fastify": "^5.0.0",
         "pino": "^9.0.0",
         "undici": "^7.0.0"
+      }
+    },
+    "node_modules/@platformatic/generators/node_modules/undici": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.1.1.tgz",
+      "integrity": "sha512-WZkQ6eH9f5ZT93gaIffsbUaDpBwjbpvmMbfaEhOnbdUneurTESeRxwPGwjI28mRFESH3W3e8Togijh37ptOQqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@platformatic/graphql-composer": {
@@ -2855,9 +2882,9 @@
       }
     },
     "node_modules/@platformatic/itc": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/itc/-/itc-2.30.0.tgz",
-      "integrity": "sha512-9W1lfrKtj5oiuXH0XFd6bxJ7NV20w41MbNL1vepti0bm4mj17ULjuiyNy+fxfQbafswO5pcAiiRJ/hapx35fNQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/itc/-/itc-2.30.1.tgz",
+      "integrity": "sha512-JBXGHES0gtrbkwvMrhbVhvOXfa1XCi17NsnDSpH2RWsIUJgf8fmdYsZqqgB6++hNesWmy2DA9KLzeEMHKIj2AA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/error": "^4.0.0",
@@ -2865,9 +2892,9 @@
       }
     },
     "node_modules/@platformatic/metrics": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/metrics/-/metrics-2.30.0.tgz",
-      "integrity": "sha512-Bm2tISNnp7T8A4cb0ZMARRqgI2xnTl7e6HZZo3dquuXVigUpmDR1dpc7scWby7JRJbAeX4RZgWmzoFgiaR6BcA==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/metrics/-/metrics-2.30.1.tgz",
+      "integrity": "sha512-1tJQ/aJJFKyOz+XNy7/hAE6CzlsVNWTeQF4gfa5ml30kkRMs88WZBwDgomG9KsTEEhejaE1i46KqK4PFX93Qqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@platformatic/http-metrics": "^0.2.1",
@@ -2876,14 +2903,14 @@
       }
     },
     "node_modules/@platformatic/node": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/node/-/node-2.30.0.tgz",
-      "integrity": "sha512-pK7/txcl4tNjGR7tRc5XC9XHcYDg2+wTJUJAC3R/HEhA+dCyRr/mWMyAMAB+jIX0KQdPDZpRMwRlPgbn1Pqt8A==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/node/-/node-2.30.1.tgz",
+      "integrity": "sha512-MQ00tbQ4BCSCm+93mPs2iMRUd0aJ+oyGz+3Pful7RQJ63tgKkaw4AIHpNgEkUcHH9IR+MF+K5oP6GWQQ0Hw4UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@platformatic/basic": "2.30.0",
-        "@platformatic/config": "2.30.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/basic": "2.30.1",
+        "@platformatic/config": "2.30.1",
+        "@platformatic/utils": "2.30.1",
         "light-my-request": "^6.0.0"
       }
     },
@@ -2900,24 +2927,25 @@
       }
     },
     "node_modules/@platformatic/runtime": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/runtime/-/runtime-2.30.0.tgz",
-      "integrity": "sha512-KT+e5r2vFsRI4ZNUTR2P9fy3LgifLblobPJgS/ZoNG1+pTUhiroKzS2xjhylzXNyaDt6T+2mquZ10a40i1Hcjw==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/runtime/-/runtime-2.30.1.tgz",
+      "integrity": "sha512-8O83sNhHJruekhXXb5t73Bzsq9Byk8fhs2MPS+TRdt6HbP26KSRdEKtq71YMCrHZvkK2+tskA08TdPhDR2iDyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/accepts": "^5.0.0",
         "@fastify/error": "^4.0.0",
         "@fastify/websocket": "^11.0.0",
         "@hapi/topo": "^6.0.2",
-        "@platformatic/basic": "2.30.0",
-        "@platformatic/config": "2.30.0",
-        "@platformatic/generators": "2.30.0",
+        "@opentelemetry/api": "^1.8.0",
+        "@platformatic/basic": "2.30.1",
+        "@platformatic/config": "2.30.1",
+        "@platformatic/generators": "2.30.1",
         "@platformatic/http-metrics": "^0.2.1",
-        "@platformatic/itc": "2.30.0",
-        "@platformatic/telemetry": "2.30.0",
-        "@platformatic/ts-compiler": "2.30.0",
+        "@platformatic/itc": "2.30.1",
+        "@platformatic/telemetry": "2.30.1",
+        "@platformatic/ts-compiler": "2.30.1",
         "@platformatic/undici-cache-memory": "^0.8.1",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/utils": "2.30.1",
         "@watchable/unpromise": "^1.0.2",
         "change-case-all": "^2.1.0",
         "close-with-grace": "^2.0.0",
@@ -2940,23 +2968,32 @@
         "tail-file-stream": "^0.2.0",
         "thread-cpu-usage": "^0.2.0",
         "undici": "^7.0.0",
-        "undici-thread-interceptor": "^0.10.0",
+        "undici-thread-interceptor": "^0.10.3",
         "ws": "^8.16.0"
       },
       "bin": {
         "plt-runtime": "runtime.mjs"
       }
     },
+    "node_modules/@platformatic/runtime/node_modules/undici": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.1.1.tgz",
+      "integrity": "sha512-WZkQ6eH9f5ZT93gaIffsbUaDpBwjbpvmMbfaEhOnbdUneurTESeRxwPGwjI28mRFESH3W3e8Togijh37ptOQqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@platformatic/scalar-theme": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/scalar-theme/-/scalar-theme-2.30.0.tgz",
-      "integrity": "sha512-lmmUKa+yG/BnMP/d/08XyybEi3hAndqygnd3MFWlLxHrLhizZO4FQZ0Zp21SRztRS75u93mrGMeXvJnDK6TMig==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/scalar-theme/-/scalar-theme-2.30.1.tgz",
+      "integrity": "sha512-tjbOPYBEyP5HLQX+KPNvNiiAQiVMIeiLjyaAcweYWlHnlptXOrh2YIlrE5MxbvFQ3OsR4UrRHcQ+II0be0rISA==",
       "license": "Apache-2.0"
     },
     "node_modules/@platformatic/service": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/service/-/service-2.30.0.tgz",
-      "integrity": "sha512-/7SPBGjIbmGzPA8y2p8gLpe1xzEYdf+RF9ih/drWuuXXto0nozXrXk/Ak3y2k1PhsLSgFj3RSSpZ5M1BLGcsRw==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/service/-/service-2.30.1.tgz",
+      "integrity": "sha512-iC4GonYOCzuYw6IdyXjnUefoLcFHVwmvD2qjVWqdNmr9f2TjSVyUEb/y4HPp2afhDB23fZ6jqmXkYu2PfarzpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/accepts": "^5.0.0",
@@ -2969,15 +3006,15 @@
         "@fastify/swagger": "^9.0.0",
         "@fastify/under-pressure": "^9.0.0",
         "@mercuriusjs/federation": "^4.0.0",
-        "@platformatic/client": "2.30.0",
-        "@platformatic/config": "2.30.0",
+        "@platformatic/client": "2.30.1",
+        "@platformatic/config": "2.30.1",
         "@platformatic/fastify-http-metrics": "^0.2.0",
-        "@platformatic/generators": "2.30.0",
-        "@platformatic/metrics": "2.30.0",
-        "@platformatic/scalar-theme": "2.30.0",
-        "@platformatic/telemetry": "2.30.0",
-        "@platformatic/ts-compiler": "2.30.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/generators": "2.30.1",
+        "@platformatic/metrics": "2.30.1",
+        "@platformatic/scalar-theme": "2.30.1",
+        "@platformatic/telemetry": "2.30.1",
+        "@platformatic/ts-compiler": "2.30.1",
+        "@platformatic/utils": "2.30.1",
         "@scalar/fastify-api-reference": "^1.19.5",
         "@types/ws": "^8.5.10",
         "ajv": "^8.12.0",
@@ -3012,10 +3049,19 @@
         "plt-service": "service.mjs"
       }
     },
+    "node_modules/@platformatic/service/node_modules/undici": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.1.1.tgz",
+      "integrity": "sha512-WZkQ6eH9f5ZT93gaIffsbUaDpBwjbpvmMbfaEhOnbdUneurTESeRxwPGwjI28mRFESH3W3e8Togijh37ptOQqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/@platformatic/telemetry": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/telemetry/-/telemetry-2.30.0.tgz",
-      "integrity": "sha512-pCIB5SA0F1LYJ8/yMXwfyVKz53hOUSNkIiNvQvVpK2n5UfTr62I4bjVIpM3X3fR9GlgBvNtH4eJmMdgUj3Vlvg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/telemetry/-/telemetry-2.30.1.tgz",
+      "integrity": "sha512-p/pQc30LkcN9M0YRH+UItNKOEJjgtl7DWY8gBWbhxFbPgbC/BgH2WLW+bBKz9f/HQ0y44p+pIcmEcGiuZDyDkQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.0.0",
@@ -3036,12 +3082,12 @@
       }
     },
     "node_modules/@platformatic/ts-compiler": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/ts-compiler/-/ts-compiler-2.30.0.tgz",
-      "integrity": "sha512-w2Vrt1Vfo+g14xF0SW83CY3DE9/Ag/SpJLD2s8dR4nUgL8YDrvpCGpndKYf/5T5Smzk802GUGQZ2OHZZZ+vhXQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/ts-compiler/-/ts-compiler-2.30.1.tgz",
+      "integrity": "sha512-V1vWAE43QzNwqTPuRladA0XFdtVnHZvlOSaMH10p7OYTSAvSGAqIr5b8M1jH9YdQt25/Ma+qCKW8oJ/DIefZ1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/utils": "2.30.1",
         "execa": "^9.0.0",
         "pino": "^9.2.0",
         "pino-pretty": "^13.0.0",
@@ -3055,9 +3101,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@platformatic/utils": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/utils/-/utils-2.30.0.tgz",
-      "integrity": "sha512-isDYfv05EcRW/oVshy3nNDYnbEXaE1sWzuFu6lxrNsD1flyndacwrHdDpP2/TNNcekoYcBptQwrsOKAc6h++1Q==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/utils/-/utils-2.30.1.tgz",
+      "integrity": "sha512-8D/UAGmPOMfxbhsKbyJrLgN1wfUnw2PY0qMecdEmur9/KelYDo5NK7Wtr/bmbs/GzEwROuV0N7TT3UmUb1rbNA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/deepmerge": "^2.0.0",
@@ -3080,16 +3126,16 @@
       }
     },
     "node_modules/@platformatic/vite": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@platformatic/vite/-/vite-2.30.0.tgz",
-      "integrity": "sha512-+uX9P+qfIZhPJH79HQxEyYD0gfCP9b2AD64jnZS2pGjFNSCOVnwyh2Ewg2hjNXB6VWOHz0EcVLOSlVurfYJ0SQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/@platformatic/vite/-/vite-2.30.1.tgz",
+      "integrity": "sha512-8NKYnWYiHL/oc7JKeMuZCnWjjppahDAFeL7C/L2WHV4PVb5mPjvPXyj3XrGigt/FSMB4HAaMfFw7j4s2A6vYAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/static": "^8.0.0",
-        "@platformatic/basic": "2.30.0",
-        "@platformatic/config": "2.30.0",
-        "@platformatic/node": "2.30.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/basic": "2.30.1",
+        "@platformatic/config": "2.30.1",
+        "@platformatic/node": "2.30.1",
+        "@platformatic/utils": "2.30.1",
         "fastify": "^5.0.0",
         "semver": "^7.6.3"
       }
@@ -8578,9 +8624,9 @@
       }
     },
     "node_modules/undici-thread-interceptor": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/undici-thread-interceptor/-/undici-thread-interceptor-0.10.2.tgz",
-      "integrity": "sha512-Hq0oypdtHSDTX5jKQv+pnDuY5ACwuBFm2TthHy8p35ZyncIAXgA3Uk5oknEE82JhS08kR8na9/bA6Kp/kuBtJw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/undici-thread-interceptor/-/undici-thread-interceptor-0.10.3.tgz",
+      "integrity": "sha512-PFWnN3/33CHzZ/qLeGkYUnCJ7xT7H9L6si6RiayGTb/0PPqB6KZHkROs4I7JkQ9/6HUo2H9rS56p+lTXMfqbmA==",
       "license": "MIT",
       "dependencies": {
         "hyperid": "^3.2.0",
@@ -8753,16 +8799,16 @@
       }
     },
     "node_modules/wattpm": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/wattpm/-/wattpm-2.30.0.tgz",
-      "integrity": "sha512-AqNZGRPiJhVIFG4MjlzRDO/JYRLDurcV+AyaMm9VY82wGZueYyI9KpPPso/r4Sj6MBTRqjWN3Mgrt9SOPhTLpg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/wattpm/-/wattpm-2.30.1.tgz",
+      "integrity": "sha512-nMqzuMgK6Pe7YuM2Azel5ly8Fs2DlxyTF55FP1YxjxDsWka6V06ZFYhk4L3LqWpdJ8JK5uJPdNKeWaHiyV9aBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@platformatic/basic": "2.30.0",
-        "@platformatic/config": "2.30.0",
-        "@platformatic/control": "2.30.0",
-        "@platformatic/runtime": "2.30.0",
-        "@platformatic/utils": "2.30.0",
+        "@platformatic/basic": "2.30.1",
+        "@platformatic/config": "2.30.1",
+        "@platformatic/control": "2.30.1",
+        "@platformatic/runtime": "2.30.1",
+        "@platformatic/utils": "2.30.1",
         "colorette": "^2.0.20",
         "commist": "^3.2.0",
         "dotenv": "^16.4.5",
@@ -9030,8 +9076,8 @@
     },
     "web/backend": {
       "dependencies": {
-        "@platformatic/control": "^2.30.0",
-        "@platformatic/service": "^2.30.0"
+        "@platformatic/control": "^2.30.1",
+        "@platformatic/service": "^2.30.1"
       },
       "devDependencies": {
         "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
@@ -9042,7 +9088,7 @@
     },
     "web/composer": {
       "dependencies": {
-        "@platformatic/composer": "^2.30.0"
+        "@platformatic/composer": "^2.30.1"
       },
       "devDependencies": {
         "borp": "^0.19.0",
@@ -9053,7 +9099,7 @@
     "web/frontend": {
       "version": "0.0.0",
       "dependencies": {
-        "@platformatic/vite": "^2.30.0",
+        "@platformatic/vite": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "wattpm start"
   },
   "dependencies": {
-    "@platformatic/composer": "^2.30.0",
-    "@platformatic/runtime": "^2.30.0",
-    "wattpm": "^2.30.0"
+    "@platformatic/composer": "^2.30.1",
+    "@platformatic/runtime": "^2.30.1",
+    "wattpm": "^2.30.1"
   },
   "workspaces": [
     "web/*",

--- a/watt.json
+++ b/watt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.platformatic.dev/wattpm/2.26.1.json",
+  "$schema": "https://schemas.platformatic.dev/wattpm/2.30.1.json",
   "server": {
     "hostname": "127.0.0.1",
     "port": 3042

--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@platformatic/control": "^2.30.0",
-    "@platformatic/service": "^2.30.0"
+    "@platformatic/control": "^2.30.1",
+    "@platformatic/service": "^2.30.1"
   }
 }

--- a/web/backend/platformatic.json
+++ b/web/backend/platformatic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.26.1.json",
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/2.30.1.json",
   "service": {
     "openapi": true
   },

--- a/web/backend/plugins/example.ts
+++ b/web/backend/plugins/example.ts
@@ -1,6 +1,6 @@
-/// <reference path="../global.d.ts" />
 import { FastifyInstance, FastifyPluginOptions } from 'fastify'
 
 export default async function (fastify: FastifyInstance, opts: FastifyPluginOptions) {
+  fastify.log.debug({ pltConfig: fastify.platformatic.configManager.current }, 'pltConfig')
   fastify.decorate('example', 'foobar')
 }

--- a/web/backend/routes/root.ts
+++ b/web/backend/routes/root.ts
@@ -1,4 +1,3 @@
-/// <reference path="../global.d.ts" />
 import { FastifyInstance, FastifyPluginOptions } from 'fastify'
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
 import { RuntimeApiClient } from '@platformatic/control'
@@ -29,8 +28,7 @@ export default async function (fastify: FastifyInstance, opts: FastifyPluginOpti
     let runtimes = await api.getRuntimes()
 
     if (!request.query.includeAdmin) {
-      // FIXME: remove `any` once the proper type is passed from `@platformatic/control`
-      runtimes = runtimes.filter((runtime: any) => runtime.packageName !== 'watt-admin')
+      runtimes = runtimes.filter((runtime) => runtime.packageName !== 'watt-admin')
     }
 
     return runtimes

--- a/web/backend/test/routes/root.test.ts
+++ b/web/backend/test/routes/root.test.ts
@@ -6,11 +6,9 @@ test('root', async (t) => {
   const server = await getServer(t)
   const res = await server.inject({
     method: 'GET',
-    url: '/example'
+    url: '/runtimes'
   })
 
   assert.strictEqual(res.statusCode, 200)
-  assert.deepStrictEqual(res.json(), {
-    hello: 'foobar'
-  })
+  assert.deepStrictEqual(res.json(), [])
 })

--- a/web/composer/package.json
+++ b/web/composer/package.json
@@ -12,6 +12,6 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@platformatic/composer": "^2.30.0"
+    "@platformatic/composer": "^2.30.1"
   }
 }

--- a/web/composer/platformatic.json
+++ b/web/composer/platformatic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.platformatic.dev/@platformatic/composer/2.26.1.json",
+  "$schema": "https://schemas.platformatic.dev/@platformatic/composer/2.30.1.json",
   "composer": {
     "services": [
       {

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@platformatic/vite": "^2.30.0"
+    "@platformatic/vite": "^2.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/web/frontend/watt.json
+++ b/web/frontend/watt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.platformatic.dev/@platformatic/vite/2.26.1.json",
+  "$schema": "https://schemas.platformatic.dev/@platformatic/vite/2.30.1.json",
   "application": {
     "basePath": "/admin"
   }


### PR DESCRIPTION
Steps done:
* update all `platformatic/wattpm` dependecies
* remove cast to `any` thanks to the [new types](https://github.com/platformatic/platformatic/pull/3745) we get from `@platformatic/control`
* remove `<reference path="../global.d.ts" />` since such global types are already inherited as confirmed by the `debug` log on `web/backend/plugins/example.ts` line `4`
* add CI action to run build and backend tests