### PR TITLE
fix(backend): latency calc

### DIFF
--- a/web/backend/plugins/metrics.ts
+++ b/web/backend/plugins/metrics.ts
@@ -60,6 +60,12 @@ export default async function (fastify: FastifyInstance) {
           p95: 0,
           p99: 0
         }
+        let aggregatedCountP90 = 0
+        let aggregatedCountP95 = 0
+        let aggregatedCountP99 = 0
+        let aggregatedSumP90 = 0
+        let aggregatedSumP95 = 0
+        let aggregatedSumP99 = 0
         const runtimeMetrics = await api.getRuntimeMetrics(pid, { format: 'json' })
         if (!fastify.mappedMetrics[pid]) {
           fastify.mappedMetrics[pid] = { services: {}, aggregated: { dataCpu: [], dataLatency: [], dataMem: [] } }
@@ -90,6 +96,12 @@ export default async function (fastify: FastifyInstance) {
             p95: 0,
             p99: 0
           }
+          let countP90 = 0
+          let countP95 = 0
+          let countP99 = 0
+          let sumP90 = 0
+          let sumP95 = 0
+          let sumP99 = 0
 
           for (const metric of runtimeMetrics) {
             if (metric.values.length > 0) {
@@ -133,19 +145,40 @@ export default async function (fastify: FastifyInstance) {
                   aggregatedCpuData.eventLoop += value
                 }
 
-                if (metric.name === 'nodejs_eventloop_lag_p90_seconds') {
-                  serviceLatencyData.p90 = value * 1000
-                  aggregatedLatencyData.p90 += serviceLatencyData.p90
-                }
-
-                if (metric.name === 'nodejs_eventloop_lag_p99_seconds') {
-                  serviceLatencyData.p99 = value * 1000
-                  aggregatedLatencyData.p99 += serviceLatencyData.p99
-                }
-
-                if (serviceLatencyData.p90 && serviceLatencyData.p99) {
-                  serviceLatencyData.p95 = (serviceLatencyData.p90 + serviceLatencyData.p99) / 2
-                  aggregatedLatencyData.p95 = (aggregatedLatencyData.p90 + aggregatedLatencyData.p99) / 2
+                if (metric.name === 'http_request_all_summary_seconds') {
+                  for (const metricValue of metric.values) {
+                    const data = metricValue.value * 1000
+                    if (data > 0) {
+                      // FIXME: update type returned by `@platformatic/control` and return also QuantileLabel inside `labels`
+                      type QuantileLabel = { quantile?: number }
+                      if ((metricValue.labels as QuantileLabel)?.quantile === 0.9) {
+                        countP90++
+                        sumP90 += data
+                        serviceLatencyData.p90 = sumP90 / countP90
+                        aggregatedLatencyData.p90 += serviceLatencyData.p90
+                        aggregatedCountP90++
+                        aggregatedSumP90 += data
+                        aggregatedLatencyData.p90 = aggregatedSumP90 / aggregatedCountP90
+                      }
+                      if ((metricValue.labels as QuantileLabel)?.quantile === 0.95) {
+                        countP95++
+                        sumP95 += data
+                        serviceLatencyData.p95 = sumP95 / countP95
+                        aggregatedLatencyData.p95 += serviceLatencyData.p95
+                        aggregatedCountP95++
+                        aggregatedSumP95 += data
+                        aggregatedLatencyData.p95 = aggregatedSumP95 / aggregatedCountP95
+                      }
+                      if ((metricValue.labels as QuantileLabel)?.quantile === 0.99) {
+                        countP99++
+                        sumP99 += data
+                        serviceLatencyData.p99 = sumP99 / countP99
+                        aggregatedCountP99++
+                        aggregatedSumP99 += data
+                        aggregatedLatencyData.p99 = aggregatedSumP99 / aggregatedCountP99
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/web/backend/plugins/metrics.ts
+++ b/web/backend/plugins/metrics.ts
@@ -1,5 +1,6 @@
 import { RuntimeApiClient } from '@platformatic/control'
 import { FastifyInstance } from 'fastify'
+import os from 'os'
 
 interface CommonMetricData {
   date: Date;
@@ -39,6 +40,7 @@ export default async function (fastify: FastifyInstance) {
     try {
       const api = new RuntimeApiClient()
       const runtimes = await api.getRuntimes()
+      const numCpus = os.cpus().length
       for (const { pid } of runtimes) {
         const date = new Date()
         const aggregatedMemData: MemoryDataPoint = {
@@ -136,13 +138,13 @@ export default async function (fastify: FastifyInstance) {
                 }
 
                 if (metric.name === 'process_cpu_percent_usage') {
-                  serviceCpuData.cpu = value
-                  aggregatedCpuData.cpu += value
+                  serviceCpuData.cpu = value / numCpus
+                  aggregatedCpuData.cpu += serviceCpuData.cpu
                 }
 
                 if (metric.name === 'nodejs_eventloop_utilization') {
-                  serviceCpuData.eventLoop = value
-                  aggregatedCpuData.eventLoop += value
+                  serviceCpuData.eventLoop = value * 100
+                  aggregatedCpuData.eventLoop += serviceCpuData.eventLoop
                 }
 
                 if (metric.name === 'http_request_all_summary_seconds') {

--- a/web/backend/test/plugins/metrics.test.ts
+++ b/web/backend/test/plugins/metrics.test.ts
@@ -33,9 +33,9 @@ test('metrics with runtime', async (t) => {
   assert.ok(metrics.dataCpu[0].eventLoop > 0)
   assert.ok(new Date(metrics.dataCpu[0].date) <= new Date())
 
-  assert.ok(metrics.dataLatency[0].p90 > 0)
-  assert.ok(metrics.dataLatency[0].p95 > 0)
-  assert.ok(metrics.dataLatency[0].p99 > 0)
+  assert.ok(metrics.dataLatency[0].p90 >= 0)
+  assert.ok(metrics.dataLatency[0].p95 >= 0)
+  assert.ok(metrics.dataLatency[0].p99 >= 0)
   assert.ok(new Date(metrics.dataLatency[0].date) <= new Date())
 
   assert.ok(metrics.dataMem[0].rss >= 0)


### PR DESCRIPTION
Get proper calculation of latency from `http_request_all_summary_seconds` metrics