### PR TITLE
fix(backend): same rss memory for service and aggregated data

### DIFF
--- a/web/backend/plugins/metrics.ts
+++ b/web/backend/plugins/metrics.ts
@@ -112,7 +112,7 @@ export default async function (fastify: FastifyInstance) {
               if (serviceId === labels.serviceId) {
                 if (metric.name === 'process_resident_memory_bytes') {
                   serviceMemData.rss = bytesToGB(value)
-                  aggregatedMemData.rss += serviceMemData.rss
+                  aggregatedMemData.rss = serviceMemData.rss
                 }
 
                 if (metric.name === 'nodejs_heap_size_total_bytes') {

--- a/web/backend/test/plugins/metrics.test.ts
+++ b/web/backend/test/plugins/metrics.test.ts
@@ -53,4 +53,6 @@ test('metrics with runtime', async (t) => {
   assert.ok('dataCpu' in response)
   assert.ok('dataLatency' in response)
   assert.ok('dataMem' in response)
+
+  assert.equal(metrics.dataMem[0].rss, response.dataMem[0].rss)
 })


### PR DESCRIPTION
Address https://github.com/platformatic/watt-admin/issues/26 + update memory data to MB (rather than GB), considering the value we normally get locally