### PR TITLE
chore(backend): ci test flakiness fixes

### DIFF
--- a/web/backend/package.json
+++ b/web/backend/package.json
@@ -2,7 +2,7 @@
   "name": "backend",
   "scripts": {
     "start": "platformatic start",
-    "test": "npm run lint && borp",
+    "test": "npm run lint && borp --concurrency 4",
     "clean": "rm -fr ./dist",
     "build": "platformatic compile",
     "lint": "eslint",

--- a/web/backend/test/plugins/metrics.test.ts
+++ b/web/backend/test/plugins/metrics.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert'
-import { getServer, startWatt, wait } from '../helper'
+import { getServer, startWatt, loadMetrics } from '../helper'
 import { MetricsResponse } from '../../utils/calc'
 
 test('metrics without runtime', async (t) => {
@@ -13,12 +13,9 @@ test('metrics without runtime', async (t) => {
 test('metrics with runtime', async (t) => {
   await startWatt(t)
   const server = await getServer(t)
-
-  await wait(1500)
-  const metricsKeys = Object.keys(server.mappedMetrics)
-  const [pid] = metricsKeys
+  await loadMetrics(server)
+  const [pid] = Object.keys(server.mappedMetrics)
   const servicePID = parseInt(pid)
-  assert.ok(metricsKeys.length > 0, 'mapped metrics are defined, and contain values')
   assert.ok(Array.isArray(server.mappedMetrics[servicePID].aggregated.dataCpu))
 
   const res = await server.inject({


### PR DESCRIPTION
Fixes applied:
* always define 4 CPU (as by Github docs for standard [Linux hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)) so that we can always test (either locally and on the CI) with the right amount of CPUs
* use a more reliable way to check for metrics to be populated rather than a simple `wait`

Also, tests now take half of the time (at least locally) to be executed:
from `duration_ms` of `5034.62` to `10263.82`