### PR TITLE
fix(deps): update package lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "@platformatic/watt-admin",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@platformatic/watt-admin",
+      "version": "0.1.2",
       "dependencies": {
         "@inquirer/prompts": "^7.3.3",
         "@platformatic/composer": "^2.55.0",
@@ -18,7 +20,7 @@
         "wattpm": "^2.55.0"
       },
       "bin": {
-        "watt-runtime": "cli.js"
+        "watt-admin": "cli.js"
       },
       "devDependencies": {
         "@fastify/type-provider-json-schema-to-ts": "^5.0.0",


### PR DESCRIPTION
I just had a look at [this](https://github.com/platformatic/watt-admin/pull/59).

`package-lock.json` was not up-to-date