### PR TITLE
feat(frontend): properly handle service data

### DIFF
--- a/web/frontend/src/client/backend.ts
+++ b/web/frontend/src/client/backend.ts
@@ -254,7 +254,7 @@ const _postRuntimesPidRestart = async (url: string, request: Types.PostRuntimesP
   const isFormData = body instanceof FormData
   const headers: HeadersInit = {
     ...defaultHeaders,
-    ...(isFormData ? {} : defaultJsonType)
+    ...(isFormData || body === undefined) ? {} : defaultJsonType
   }
 
   const response = await fetch(`${url}/runtimes/${request.path['pid']}/restart`, {

--- a/web/frontend/src/components/application/ServicesBox.tsx
+++ b/web/frontend/src/components/application/ServicesBox.tsx
@@ -61,13 +61,11 @@ function ServiceDetailPanel ({ openapi, pid, service, onClose }: ServiceDetailPa
 }
 
 interface ServiceProps {
-  id: string;
-  entrypoint?: boolean;
-  type?: string;
+  service: ServiceData;
   onServiceClick: (id: string) => void;
 }
 
-function Service ({ id, entrypoint, type, onServiceClick }: ServiceProps): React.ReactElement {
+function Service ({ service, onServiceClick }: ServiceProps): React.ReactElement {
   return (
     <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth} ${commonStyles.flexGrow}`}>
       <BorderedBox
@@ -79,12 +77,12 @@ function Service ({ id, entrypoint, type, onServiceClick }: ServiceProps): React
         backgroundColorOpacityOver={OPACITY_15}
         backgroundColorOver={WHITE}
         clickable
-        onClick={() => onServiceClick(id)}
+        onClick={() => onServiceClick(service.id)}
       >
         <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth} ${commonStyles.flexGrow}`}>
           <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth}`}>
             {
-              entrypoint
+              'entrypoint' in service
                 ? <Icons.EntrypointIcon
                     color={WHITE}
                     size={SMALL}
@@ -94,11 +92,11 @@ function Service ({ id, entrypoint, type, onServiceClick }: ServiceProps): React
                     size={SMALL}
                   />
             }
-            <span className={`${typographyStyles.textWhite}`}>{id}</span>
-            {entrypoint &&
+            <span className={`${typographyStyles.textWhite}`}>{service.id}</span>
+            {'entrypoint' in service &&
               <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}>(Application Entrypoint)</span>}
 
-            <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}> | &nbsp; Service Type: {type}</span>
+            {'type' in service && <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}> | &nbsp; Service Type: {service.type}</span>}
           </div>
           <div className={`${styles.w45} ${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}>Test it</div>
           <Icons.InternalLinkIcon className={`${typographyStyles.opacity70}`} color={WHITE} size={SMALL} />
@@ -167,13 +165,11 @@ function ServicesBox (): React.ReactElement {
             </div>
           </div>
           <div className={`${commonStyles.tinyFlexBlock} ${commonStyles.fullWidth}`}>
-            {services.map(({ id, entrypoint, type }) => (
+            {services.map((service) => (
               <Service
-                key={id}
-                id={id}
-                entrypoint={entrypoint}
-                type={type}
-                onServiceClick={() => setSelectedService(id)}
+                key={service.id}
+                service={service}
+                onServiceClick={() => setSelectedService(service.id)}
               />
             ))}
           </div>

--- a/web/frontend/src/components/application/ServicesBox.tsx
+++ b/web/frontend/src/components/application/ServicesBox.tsx
@@ -11,6 +11,7 @@ import { ServiceData } from 'src/types'
 import ErrorComponent from '../errors/ErrorComponent'
 import { HOME_PATH } from '../../ui-constants'
 import { useNavigate } from 'react-router-dom'
+import { getServiceEntrypoint } from '../../utilities/getters'
 
 interface ServiceDetailPanelProps {
   openapi: unknown;
@@ -82,7 +83,7 @@ function Service ({ service, onServiceClick }: ServiceProps): React.ReactElement
         <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth} ${commonStyles.flexGrow}`}>
           <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth}`}>
             {
-              'entrypoint' in service
+              getServiceEntrypoint(service)
                 ? <Icons.EntrypointIcon
                     color={WHITE}
                     size={SMALL}
@@ -93,7 +94,7 @@ function Service ({ service, onServiceClick }: ServiceProps): React.ReactElement
                   />
             }
             <span className={`${typographyStyles.textWhite}`}>{service.id}</span>
-            {'entrypoint' in service &&
+            {getServiceEntrypoint(service) &&
               <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}>(Application Entrypoint)</span>}
 
             {'type' in service && <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}> | &nbsp; Service Type: {service.type}</span>}

--- a/web/frontend/src/components/services/ServicesCharts.tsx
+++ b/web/frontend/src/components/services/ServicesCharts.tsx
@@ -11,6 +11,7 @@ import { POD_SERVICES_PATH } from '../../ui-constants'
 import { getServices } from '../../api'
 import { ServiceData } from 'src/types'
 import ErrorComponent from '../errors/ErrorComponent'
+import { getServiceWorkers } from '../../utilities/getters'
 
 const ServicesCharts: React.FC = () => {
   const globalState = useAdminStore()
@@ -18,7 +19,7 @@ const ServicesCharts: React.FC = () => {
   const [error, setError] = useState<unknown>(undefined)
   const [showAggregatedMetrics, setShowAggregatedMetrics] = useState(true)
   const [services, setServices] = useState<ServiceData[]>([])
-  const [serviceSelected, setServiceSelected] = useState<ServiceData>({ id: '', selected: false })
+  const [serviceSelected, setServiceSelected] = useState<ServiceData>({ id: '', status: '' })
   const [threadIndex, setThreadIndex] = useState<ThreadIndex>()
 
   useEffect(() => {
@@ -66,14 +67,14 @@ const ServicesCharts: React.FC = () => {
               serviceSelected={serviceSelected}
               handleClickService={(service) => {
                 setServiceSelected(service)
-                if (hasMultipleWorkers(service.workers)) {
+                if (hasMultipleWorkers(getServiceWorkers(service))) {
                   setThreadIndex('all')
                 } else {
                   setThreadIndex(undefined)
                 }
               }}
               handleClickThread={(threadIndex) => {
-                if (hasMultipleWorkers(serviceSelected.workers)) {
+                if (hasMultipleWorkers(getServiceWorkers(serviceSelected))) {
                   setThreadIndex(threadIndex)
                 } else {
                   setThreadIndex(undefined)

--- a/web/frontend/src/components/services/ServicesLogs.tsx
+++ b/web/frontend/src/components/services/ServicesLogs.tsx
@@ -11,6 +11,7 @@ import { POD_LOGS_PATH } from '../../ui-constants'
 import { getServices } from '../../api'
 import { ServiceData } from 'src/types'
 import ErrorComponent from '../errors/ErrorComponent'
+import { getServiceSelected } from '../../utilities/getters'
 
 const ServicesLogs: React.FC = () => {
   const globalState = useAdminStore()
@@ -46,17 +47,17 @@ const ServicesLogs: React.FC = () => {
   function handleChangeService (serviceUpdated: ServiceData): void {
     const newServices = services.map(service => {
       if (serviceUpdated.id === service.id) {
-        return { ...service, selected: !service.selected }
+        return { ...service, selected: !getServiceSelected(service) }
       } else {
         return { ...service }
       }
     })
     // if all selected but not find a service that is selected, turn off the toggle
-    if (selectAllServices && newServices.find(service => !service.selected) !== undefined) {
+    if (selectAllServices && newServices.find(service => !getServiceSelected(service)) !== undefined) {
       setSelectAllServices(false)
     }
     // if no service is selected but not all service select correspont to length of all service
-    if (!selectAllServices && newServices.filter(service => service.selected).length === newServices.length) {
+    if (!selectAllServices && newServices.filter(getServiceSelected).length === newServices.length) {
       setSelectAllServices(true)
     }
     setServices(newServices)
@@ -93,7 +94,7 @@ const ServicesLogs: React.FC = () => {
               handleChangeAllServices={() => handleChangeAllService()}
             />
             <AppLogs
-              filteredServices={services.filter(service => service.selected).map(service => service.id)}
+              filteredServices={services.filter(getServiceSelected).map(service => service.id)}
             />
           </div>
         </BorderedBox>

--- a/web/frontend/src/components/services/ServicesSelectorForCharts.tsx
+++ b/web/frontend/src/components/services/ServicesSelectorForCharts.tsx
@@ -5,10 +5,12 @@ import styles from './ServicesSelector.module.css'
 import { OPACITY_100, OPACITY_15, OPACITY_30, RICH_BLACK, SMALL, TRANSPARENT, WHITE } from '@platformatic/ui-components/src/components/constants'
 import { Icons, BorderedBox, Forms } from '@platformatic/ui-components'
 import { ServiceData } from 'src/types'
+import { getServiceWorkers } from '../../utilities/getters'
 
 export type ThreadIndex = number | 'all'
 
-interface ServiceProps extends ServiceData {
+type ServiceProps = {
+  service: ServiceData
   isSelected: boolean;
   selectedThread?: ThreadIndex;
   onClickService: () => void;
@@ -20,16 +22,15 @@ export const getThreadName = (idx: ThreadIndex): string => idx === 'all' ? 'All 
 export const hasMultipleWorkers = (workers?: number): workers is number => workers ? workers > 1 : false
 
 function Service ({
-  id,
-  entrypoint,
+  service,
   isSelected,
-  workers,
   onClickService,
   selectedThread = 'all',
   onSelectThread
 }: ServiceProps): React.ReactElement {
   const [selected] = useState(isSelected)
-  const multipleWorkers = hasMultipleWorkers(workers)
+  const workers = getServiceWorkers(service)
+  const multipleWorkers = hasMultipleWorkers(getServiceWorkers(service))
   const showAllThreads = () => {
     const allThreads = []
     if (multipleWorkers) {
@@ -66,8 +67,8 @@ function Service ({
       <div className={`${commonStyles.miniFlexBlock} ${commonStyles.fullWidth}`}>
         <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth} ${commonStyles.justifyBetween}`}>
           <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth}`}>
-            <span className={`${typographyStyles.desktopBodySmall} ${typographyStyles.textWhite}`}>{id}</span>
-            {entrypoint &&
+            <span className={`${typographyStyles.desktopBodySmall} ${typographyStyles.textWhite}`}>{service.id}</span>
+            {'entrypoint' in service &&
               <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}>(Entrypoint)</span>}
           </div>
           {multipleWorkers && (selected ? <span><Icons.ArrowDownIcon color={WHITE} size={SMALL} /></span> : <span className={`${typographyStyles.opacity70}`}><Icons.ArrowRightIcon color={WHITE} size={SMALL} /></span>)}
@@ -119,7 +120,7 @@ function ServicesSelectorForCharts ({
           return (
             <Service
               key={`${service.id}-$${service.selected}`}
-              {...service}
+              service={service}
               isSelected={isSelected}
               onClickService={() => handleClickService(service)}
               selectedThread={isSelected ? selectedThread : 'all'}

--- a/web/frontend/src/components/services/ServicesSelectorForCharts.tsx
+++ b/web/frontend/src/components/services/ServicesSelectorForCharts.tsx
@@ -5,7 +5,7 @@ import styles from './ServicesSelector.module.css'
 import { OPACITY_100, OPACITY_15, OPACITY_30, RICH_BLACK, SMALL, TRANSPARENT, WHITE } from '@platformatic/ui-components/src/components/constants'
 import { Icons, BorderedBox, Forms } from '@platformatic/ui-components'
 import { ServiceData } from 'src/types'
-import { getServiceWorkers } from '../../utilities/getters'
+import { getServiceEntrypoint, getServiceWorkers } from '../../utilities/getters'
 
 export type ThreadIndex = number | 'all'
 
@@ -68,7 +68,7 @@ function Service ({
         <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth} ${commonStyles.justifyBetween}`}>
           <div className={`${commonStyles.tinyFlexRow} ${commonStyles.fullWidth}`}>
             <span className={`${typographyStyles.desktopBodySmall} ${typographyStyles.textWhite}`}>{service.id}</span>
-            {'entrypoint' in service &&
+            {getServiceEntrypoint(service) &&
               <span className={`${typographyStyles.desktopBodySmallest} ${typographyStyles.textWhite} ${typographyStyles.opacity70}`}>(Entrypoint)</span>}
           </div>
           {multipleWorkers && (selected ? <span><Icons.ArrowDownIcon color={WHITE} size={SMALL} /></span> : <span className={`${typographyStyles.opacity70}`}><Icons.ArrowRightIcon color={WHITE} size={SMALL} /></span>)}

--- a/web/frontend/src/components/services/ServicesSelectorForDetailLog.tsx
+++ b/web/frontend/src/components/services/ServicesSelectorForDetailLog.tsx
@@ -5,6 +5,7 @@ import styles from './ServicesSelector.module.css'
 import { OPACITY_100, OPACITY_15, OPACITY_30, RICH_BLACK, SMALL, TRANSPARENT, WHITE } from '@platformatic/ui-components/src/components/constants'
 import { BorderedBox, Checkbox, Icons, Forms } from '@platformatic/ui-components'
 import { ServiceData } from 'src/types'
+import { getServiceSelected } from '../../utilities/getters'
 
 interface ServiceProps {
   id: string;
@@ -66,7 +67,7 @@ function ServicesSelectorForDetailLog ({
           size={SMALL}
         />}
       <div className={`${commonStyles.tinyFlexBlock} ${commonStyles.fullWidth}`}>
-        {services.map(service => <Service key={service.id} {...service} isSelected={service.selected || false} onChangeService={() => handleChangeService(service)} />)}
+        {services.map(service => <Service key={service.id} {...service} isSelected={getServiceSelected(service)} onChangeService={() => handleChangeService(service)} />)}
       </div>
     </div>
   )

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -1,7 +1,3 @@
-export interface ServiceData {
-  id: string;
-  entrypoint?: boolean;
-  type?: string;
-  workers?: number;
-  selected?: boolean;
-}
+import { GetRuntimesPidServicesResponseOK } from './client/backend-types'
+
+export type ServiceData = GetRuntimesPidServicesResponseOK['services'][number] & { selected?: boolean }

--- a/web/frontend/src/utilities/getters.ts
+++ b/web/frontend/src/utilities/getters.ts
@@ -3,3 +3,5 @@ import { ServiceData } from 'src/types'
 export const getServiceSelected = (service: ServiceData): boolean => 'selected' in service ? !!service.selected : false
 
 export const getServiceWorkers = (service: ServiceData): number => 'workers' in service ? (service.workers ? service.workers : 0) : 0
+
+export const getServiceEntrypoint = (service: ServiceData): boolean => 'entrypoint' in service ? service.entrypoint : false

--- a/web/frontend/src/utilities/getters.ts
+++ b/web/frontend/src/utilities/getters.ts
@@ -1,0 +1,5 @@
+import { ServiceData } from 'src/types'
+
+export const getServiceSelected = (service: ServiceData): boolean => 'selected' in service ? !!service.selected : false
+
+export const getServiceWorkers = (service: ServiceData): number => 'workers' in service ? (service.workers ? service.workers : 0) : 0

--- a/web/frontend/test/utilities/getters.test.ts
+++ b/web/frontend/test/utilities/getters.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { getServiceSelected, getServiceWorkers } from '../../src/utilities/getters'
+import { getServiceSelected, getServiceWorkers, getServiceEntrypoint } from '../../src/utilities/getters'
 import { ServiceData } from '../../src/types'
 
 describe('getServiceSelected', () => {
@@ -98,5 +98,62 @@ describe('getServiceWorkers', () => {
   test('should work when service has both selected and workers properties', () => {
     const service = { selected: true, workers: 10 } as ServiceData
     expect(getServiceWorkers(service)).toBe(10)
+  })
+})
+
+describe('getServiceEntrypoint', () => {
+  test('should return true when service has entrypoint property set to true', () => {
+    const service = { entrypoint: true } as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(true)
+  })
+
+  test('should return false when service has entrypoint property set to false', () => {
+    const service = { entrypoint: false } as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(false)
+  })
+
+  test('should return null when service has entrypoint property set to null', () => {
+    const service = { entrypoint: null } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(null)
+  })
+
+  test('should return undefined when service has entrypoint property set to undefined', () => {
+    const service = { entrypoint: undefined } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(undefined)
+  })
+
+  test('should return 0 when service has entrypoint property set to 0', () => {
+    const service = { entrypoint: 0 } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(0)
+  })
+
+  test('should return non-zero number when service has entrypoint property set to non-zero number', () => {
+    const service = { entrypoint: 1 } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(1)
+  })
+
+  test('should return empty string when service has entrypoint property set to empty string', () => {
+    const service = { entrypoint: '' } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe('')
+  })
+
+  test('should return string when service has entrypoint property set to non-empty string', () => {
+    const service = { entrypoint: 'main' } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe('main')
+  })
+
+  test('should return false when service does not have entrypoint property', () => {
+    const service = {} as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(false)
+  })
+
+  test('should return false when service has other properties but not entrypoint', () => {
+    const service = { name: 'test-service', workers: 5, selected: true } as unknown as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(false)
+  })
+
+  test('should work when service has entrypoint along with other properties', () => {
+    const service = { selected: true, workers: 10, entrypoint: true } as ServiceData
+    expect(getServiceEntrypoint(service)).toBe(true)
   })
 })

--- a/web/frontend/test/utilities/getters.test.ts
+++ b/web/frontend/test/utilities/getters.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from 'vitest'
+import { getServiceSelected, getServiceWorkers } from '../../src/utilities/getters'
+import { ServiceData } from '../../src/types'
+
+describe('getServiceSelected', () => {
+  test('should return true when service has selected property set to true', () => {
+    const service = { selected: true } as ServiceData
+    expect(getServiceSelected(service)).toBe(true)
+  })
+
+  test('should return false when service has selected property set to false', () => {
+    const service = { selected: false } as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return false when service has selected property set to null', () => {
+    const service = { selected: null } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return false when service has selected property set to undefined', () => {
+    const service = { selected: undefined } as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return false when service has selected property set to 0', () => {
+    const service = { selected: 0 } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return true when service has selected property set to non-zero number', () => {
+    const service = { selected: 1 } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(true)
+  })
+
+  test('should return false when service has selected property set to empty string', () => {
+    const service = { selected: '' } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return true when service has selected property set to non-empty string', () => {
+    const service = { selected: 'true' } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(true)
+  })
+
+  test('should return false when service does not have selected property', () => {
+    const service = {} as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+
+  test('should return false when service has other properties but not selected', () => {
+    const service = { name: 'test-service', workers: 5 } as unknown as ServiceData
+    expect(getServiceSelected(service)).toBe(false)
+  })
+})
+
+describe('getServiceWorkers', () => {
+  test('should return correct number when service has workers property with positive value', () => {
+    const service = { workers: 5 } as ServiceData
+    expect(getServiceWorkers(service)).toBe(5)
+  })
+
+  test('should return 0 when service has workers property set to 0', () => {
+    const service = { workers: 0 } as ServiceData
+    expect(getServiceWorkers(service)).toBe(0)
+  })
+
+  test('should return 0 when service has workers property set to null', () => {
+    const service = { workers: null } as unknown as ServiceData
+    expect(getServiceWorkers(service)).toBe(0)
+  })
+
+  test('should return 0 when service has workers property set to undefined', () => {
+    const service = { workers: undefined } as ServiceData
+    expect(getServiceWorkers(service)).toBe(0)
+  })
+
+  test('should return 0 when service does not have workers property', () => {
+    const service = {} as ServiceData
+    expect(getServiceWorkers(service)).toBe(0)
+  })
+
+  test('should return 0 when service has other properties but not workers', () => {
+    const service = { name: 'test-service', selected: true } as unknown as ServiceData
+    expect(getServiceWorkers(service)).toBe(0)
+  })
+
+  test('should handle negative numbers correctly', () => {
+    const service = { workers: -5 } as ServiceData
+    expect(getServiceWorkers(service)).toBe(-5)
+  })
+
+  test('should handle decimal numbers correctly', () => {
+    const service = { workers: 3.5 } as ServiceData
+    expect(getServiceWorkers(service)).toBe(3.5)
+  })
+
+  test('should work when service has both selected and workers properties', () => {
+    const service = { selected: true, workers: 10 } as ServiceData
+    expect(getServiceWorkers(service)).toBe(10)
+  })
+})


### PR DESCRIPTION
Some services (like the runtimes with `kafka`) may only have `{ id, status }` as metadata. This PR updates the code accordingly, both on the frontend and TypeScript sides, using the auto-generated OpenAPI schema directly.