### PR TITLE
feat(metrics): kafka

### DIFF
--- a/web/backend/openapi.json
+++ b/web/backend/openapi.json
@@ -141,13 +141,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }
@@ -296,13 +345,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }
@@ -459,13 +557,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }

--- a/web/backend/routes/metrics.ts
+++ b/web/backend/routes/metrics.ts
@@ -1,10 +1,10 @@
 import { FastifyInstance } from 'fastify'
 import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
-import { metricResponseSchema, pidParamSchema } from '../schemas'
+import { metricResponseSchema, MetricsResponse, pidParamSchema } from '../schemas'
 
 export default async function (fastify: FastifyInstance) {
   const typedFastify = fastify.withTypeProvider<JsonSchemaToTsProvider>()
-  const emptyMetrics = { dataCpu: [], dataLatency: [], dataMem: [], dataReq: [] }
+  const emptyMetrics: MetricsResponse = { dataCpu: [], dataLatency: [], dataMem: [], dataReq: [], dataKafka: [] }
 
   typedFastify.get('/runtimes/:pid/metrics', {
     schema: { params: pidParamSchema, response: { 200: metricResponseSchema } },

--- a/web/backend/schemas/index.ts
+++ b/web/backend/schemas/index.ts
@@ -54,6 +54,34 @@ const requestDataPointSchema = {
 } as const
 export type RequestDataPoint = FromSchema<typeof requestDataPointSchema>
 
+const kafkaDataPointSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    date: { type: 'string', format: 'date-time' },
+    producers: { type: 'number' },
+    producedMessages: { type: 'number' },
+    consumers: { type: 'number' },
+    consumersStreams: { type: 'number' },
+    consumersTopics: { type: 'number' },
+    consumedMessages: { type: 'number' },
+    hooksMessagesInFlight: { type: 'number' },
+    hooksDlqMessagesTotal: { type: 'number' },
+  },
+  required: [
+    'date',
+    'producers',
+    'producedMessages',
+    'consumers',
+    'consumersStreams',
+    'consumersTopics',
+    'consumedMessages',
+    'hooksMessagesInFlight',
+    'hooksDlqMessagesTotal',
+  ]
+} as const
+export type KafkaDataPoint = FromSchema<typeof kafkaDataPointSchema>
+
 export const metricResponseSchema = {
   type: 'object',
   additionalProperties: false,
@@ -61,9 +89,10 @@ export const metricResponseSchema = {
     dataMem: { type: 'array', items: memoryDataPointSchema },
     dataCpu: { type: 'array', items: cpuDataPointSchema },
     dataLatency: { type: 'array', items: latencyDataPointSchema },
-    dataReq: { type: 'array', items: requestDataPointSchema }
+    dataReq: { type: 'array', items: requestDataPointSchema },
+    dataKafka: { type: 'array', items: kafkaDataPointSchema },
   },
-  required: ['dataMem', 'dataCpu', 'dataLatency', 'dataReq']
+  required: ['dataMem', 'dataCpu', 'dataLatency', 'dataReq', 'dataKafka']
 } as const
 export type MetricsResponse = FromSchema<typeof metricResponseSchema>
 

--- a/web/backend/test/fixtures/metrics.ts
+++ b/web/backend/test/fixtures/metrics.ts
@@ -13676,5 +13676,95 @@ export const metricFixtures: Metric[] = [
       }
     ],
     aggregator: 'sum'
+  }, {
+    help: 'Number of active Kafka producers',
+    name: 'kafka_producers',
+    type: 'gauge',
+    values: [
+      {
+        value: 2,
+        labels: {
+          serviceId: 'kafka',
+          workerId: 1
+        }
+      }
+    ],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of produced Kafka messages',
+    name: 'kafka_produced_messages',
+    type: 'counter',
+    values: [
+      {
+        value: 0,
+        labels: {
+          serviceId: 'kafka',
+          workerId: 1
+        }
+      }
+    ],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of active Kafka consumers',
+    name: 'kafka_consumers',
+    type: 'gauge',
+    values: [{
+      value: 1,
+      labels: { serviceId: 'kafka', workerId: 1 }
+    }
+    ],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of active Kafka consumers streams',
+    name: 'kafka_consumers_streams',
+    type: 'gauge',
+    values: [{ value: 1, labels: { serviceId: 'kafka', workerId: 1 } }],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of topics being consumed',
+    name: 'kafka_consumers_topics',
+    type: 'gauge',
+    values: [
+      {
+        value: 1,
+        labels: {
+          serviceId: 'kafka',
+          workerId: 1
+        }
+      }
+    ],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of consumed Kafka messages',
+    name: 'kafka_consumed_messages',
+    type: 'counter',
+    values: [{ value: 0, labels: { serviceId: 'kafka', workerId: 1 } }],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Number of messages currently being processed',
+    name: 'kafka_hooks_messages_in_flight',
+    type: 'gauge',
+    values: [],
+    aggregator: 'sum'
+  },
+  {
+    name: 'kafka_hooks_http_request_duration_seconds',
+    help: 'HTTP request duration for webhook deliveries',
+    type: 'histogram',
+    values: [],
+    aggregator: 'sum'
+  },
+  {
+    help: 'Total number of messages sent to the DLQ (Dead Letter Queue)',
+    name: 'kafka_hooks_dlq_messages_total',
+    type: 'counter',
+    values: [],
+    aggregator: 'sum'
   }
 ]

--- a/web/backend/test/plugins/metrics.test.ts
+++ b/web/backend/test/plugins/metrics.test.ts
@@ -45,6 +45,16 @@ test('metrics with runtime', async (t) => {
   assert.ok(metrics.dataReq[0].count >= 0)
   assert.ok(new Date(metrics.dataReq[0].date) <= new Date())
 
+  assert.ok(metrics.dataKafka[0].producers >= 0)
+  assert.ok(metrics.dataKafka[0].producedMessages >= 0)
+  assert.ok(metrics.dataKafka[0].consumers >= 0)
+  assert.ok(metrics.dataKafka[0].consumersStreams >= 0)
+  assert.ok(metrics.dataKafka[0].consumersTopics >= 0)
+  assert.ok(metrics.dataKafka[0].consumedMessages >= 0)
+  assert.ok(metrics.dataKafka[0].hooksMessagesInFlight >= 0)
+  assert.ok(metrics.dataKafka[0].hooksDlqMessagesTotal >= 0)
+  assert.ok(new Date(metrics.dataKafka[0].date) <= new Date())
+
   const backendMetrics = await server.inject({
     url: `/runtimes/${pid}/metrics/backend`
   })
@@ -54,6 +64,7 @@ test('metrics with runtime', async (t) => {
   assert.ok('dataLatency' in response)
   assert.ok('dataMem' in response)
   assert.ok('dataReq' in response)
+  assert.ok('dataKafka' in response)
 
   const composer = await server.inject({
     url: `/runtimes/${pid}/metrics/composer`

--- a/web/backend/test/routes/metrics.test.ts
+++ b/web/backend/test/routes/metrics.test.ts
@@ -1,9 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert'
 import { getServer, startWatt, loadMetrics } from '../helper'
+import { MetricsResponse } from '../../schemas'
 
 test('metrics are calculated', async (t) => {
-  const emptyMetrics = { dataCpu: [], dataLatency: [], dataMem: [], dataReq: [] }
+  const emptyMetrics: MetricsResponse = { dataCpu: [], dataLatency: [], dataMem: [], dataReq: [], dataKafka: [] }
 
   await startWatt(t)
   const server = await getServer(t)
@@ -31,6 +32,8 @@ test('metrics are calculated', async (t) => {
   assert.ok('dataCpu' in metricsJson)
   assert.ok('dataLatency' in metricsJson)
   assert.ok('dataMem' in metricsJson)
+  assert.ok('dataReq' in metricsJson)
+  assert.ok('dataKafka' in metricsJson)
   assert.notDeepEqual(metricsJson, {}, 'metrics are not empty after the interval')
 
   const serviceMetrics = await server.inject({

--- a/web/frontend/src/client/backend-types.d.ts
+++ b/web/frontend/src/client/backend-types.d.ts
@@ -13,7 +13,7 @@ export type GetRuntimesPidMetricsRequest = {
 /**
  * Default Response
  */
-export type GetRuntimesPidMetricsResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }> }
+export type GetRuntimesPidMetricsResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }>; 'dataKafka': Array<{ 'date': string; 'producers': number; 'producedMessages': number; 'consumers': number; 'consumersStreams': number; 'consumersTopics': number; 'consumedMessages': number; 'hooksMessagesInFlight': number; 'hooksDlqMessagesTotal': number }> }
 export type GetRuntimesPidMetricsResponses =
   FullResponse<GetRuntimesPidMetricsResponseOK, 200>
 
@@ -27,7 +27,7 @@ export type GetRuntimesPidMetricsServiceIdRequest = {
 /**
  * Default Response
  */
-export type GetRuntimesPidMetricsServiceIdResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }> }
+export type GetRuntimesPidMetricsServiceIdResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }>; 'dataKafka': Array<{ 'date': string; 'producers': number; 'producedMessages': number; 'consumers': number; 'consumersStreams': number; 'consumersTopics': number; 'consumedMessages': number; 'hooksMessagesInFlight': number; 'hooksDlqMessagesTotal': number }> }
 export type GetRuntimesPidMetricsServiceIdResponses =
   FullResponse<GetRuntimesPidMetricsServiceIdResponseOK, 200>
 
@@ -42,7 +42,7 @@ export type GetRuntimesPidMetricsServiceIdWorkerIdRequest = {
 /**
  * Default Response
  */
-export type GetRuntimesPidMetricsServiceIdWorkerIdResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }> }
+export type GetRuntimesPidMetricsServiceIdWorkerIdResponseOK = { 'dataMem': Array<{ 'date': string; 'rss': number; 'totalHeap': number; 'usedHeap': number; 'newSpace': number; 'oldSpace': number }>; 'dataCpu': Array<{ 'date': string; 'cpu': number; 'eventLoop': number }>; 'dataLatency': Array<{ 'date': string; 'p90': number; 'p95': number; 'p99': number }>; 'dataReq': Array<{ 'date': string; 'count': number; 'rps': number }>; 'dataKafka': Array<{ 'date': string; 'producers': number; 'producedMessages': number; 'consumers': number; 'consumersStreams': number; 'consumersTopics': number; 'consumedMessages': number; 'hooksMessagesInFlight': number; 'hooksDlqMessagesTotal': number }> }
 export type GetRuntimesPidMetricsServiceIdWorkerIdResponses =
   FullResponse<GetRuntimesPidMetricsServiceIdWorkerIdResponseOK, 200>
 

--- a/web/frontend/src/client/backend.openapi.json
+++ b/web/frontend/src/client/backend.openapi.json
@@ -141,13 +141,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }
@@ -296,13 +345,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }
@@ -459,13 +557,62 @@
                           "rps"
                         ]
                       }
+                    },
+                    "dataKafka": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "producers": {
+                            "type": "number"
+                          },
+                          "producedMessages": {
+                            "type": "number"
+                          },
+                          "consumers": {
+                            "type": "number"
+                          },
+                          "consumersStreams": {
+                            "type": "number"
+                          },
+                          "consumersTopics": {
+                            "type": "number"
+                          },
+                          "consumedMessages": {
+                            "type": "number"
+                          },
+                          "hooksMessagesInFlight": {
+                            "type": "number"
+                          },
+                          "hooksDlqMessagesTotal": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "producers",
+                          "producedMessages",
+                          "consumers",
+                          "consumersStreams",
+                          "consumersTopics",
+                          "consumedMessages",
+                          "hooksMessagesInFlight",
+                          "hooksDlqMessagesTotal"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "dataMem",
                     "dataCpu",
                     "dataLatency",
-                    "dataReq"
+                    "dataReq",
+                    "dataKafka"
                   ]
                 }
               }

--- a/web/frontend/src/components/application/NodeJSMetrics.tsx
+++ b/web/frontend/src/components/application/NodeJSMetrics.tsx
@@ -12,15 +12,12 @@ import useAdminStore from '../../useAdminStore'
 import type { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
 import ErrorComponent from '../errors/ErrorComponent'
 
+export const getEmptyMetrics = (): GetRuntimesPidMetricsResponseOK => ({ dataMem: [], dataCpu: [], dataLatency: [], dataReq: [], dataKafka: [] })
+
 function NodeJSMetrics (): React.ReactElement {
   const [error, setError] = useState<unknown>(undefined)
   const [initialLoading, setInitialLoading] = useState(true)
-  const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>({
-    dataMem: [],
-    dataCpu: [],
-    dataLatency: [],
-    dataReq: []
-  })
+  const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
   const { runtimePid } = useAdminStore()
 
   const getData = async (): Promise<void> => {

--- a/web/frontend/src/components/metrics/ServicesMetrics.tsx
+++ b/web/frontend/src/components/metrics/ServicesMetrics.tsx
@@ -16,6 +16,7 @@ import { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
 import ErrorComponent from '../errors/ErrorComponent'
 import { ServiceData } from 'src/types'
 import { getThreadName, ThreadIndex } from '../services/ServicesSelectorForCharts'
+import { getEmptyMetrics } from '../application/NodeJSMetrics'
 
 interface ServicesMetricsProps {
   service: ServiceData;
@@ -31,18 +32,8 @@ function ServicesMetrics ({
   const threadName = threadIndex ? getThreadName(threadIndex) : ''
   const [error, setError] = useState<unknown>(undefined)
   const [initialLoading, setInitialLoading] = useState(true)
-  const [serviceData, setServiceData] = useState<GetRuntimesPidMetricsResponseOK>({
-    dataMem: [],
-    dataCpu: [],
-    dataLatency: [],
-    dataReq: []
-  })
-  const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>({
-    dataMem: [],
-    dataCpu: [],
-    dataLatency: [],
-    dataReq: []
-  })
+  const [serviceData, setServiceData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
+  const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
   const { runtimePid } = useAdminStore()
 
   const getData = async (): Promise<void> => {


### PR DESCRIPTION
Handle metrics from `kafka` stackable. Requires [this](https://github.com/platformatic/watt-admin/pull/92) upgrade first to properly work at runtime.