### PR TITLE
feat(kafka): add kafka metrics ui

### DIFF
--- a/web/frontend/src/components/application/NodeJSMetric.tsx
+++ b/web/frontend/src/components/application/NodeJSMetric.tsx
@@ -12,7 +12,7 @@ import type { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
 
 type DataValues = GetRuntimesPidMetricsResponseOK[keyof GetRuntimesPidMetricsResponseOK]
 
-export type MetricType = 'mem' | 'cpu' | 'latency' | 'req'
+export type MetricType = 'mem' | 'cpu' | 'latency' | 'req' | 'kafka'
 
 interface NodeJSMetricProps {
   title: string;

--- a/web/frontend/src/components/application/NodeJSMetrics.tsx
+++ b/web/frontend/src/components/application/NodeJSMetrics.tsx
@@ -6,11 +6,12 @@ import typographyStyles from '../../styles/Typography.module.css'
 import commonStyles from '../../styles/CommonStyles.module.css'
 import { BorderedBox, Icons } from '@platformatic/ui-components'
 import NodeJSMetric from './NodeJSMetric'
-import { REFRESH_INTERVAL_METRICS, MEMORY_UNIT_METRICS, LATENCY_UNIT_METRICS, CPU_UNIT_METRICS, REQ_UNIT_METRICS } from '../../ui-constants'
+import { REFRESH_INTERVAL_METRICS, MEMORY_UNIT_METRICS, LATENCY_UNIT_METRICS, CPU_UNIT_METRICS, REQ_UNIT_METRICS, KAFKA_UNIT_METRICS } from '../../ui-constants'
 import { getApiMetricsPod } from '../../api'
 import useAdminStore from '../../useAdminStore'
 import type { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
 import ErrorComponent from '../errors/ErrorComponent'
+import { getKafkaType } from '../../utilities/getters'
 
 export const getEmptyMetrics = (): GetRuntimesPidMetricsResponseOK => ({ dataMem: [], dataCpu: [], dataLatency: [], dataReq: [], dataKafka: [] })
 
@@ -19,6 +20,7 @@ function NodeJSMetrics (): React.ReactElement {
   const [initialLoading, setInitialLoading] = useState(true)
   const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
   const { runtimePid } = useAdminStore()
+  const [hasKafkaData, setHasKafkaData] = useState(false)
 
   const getData = async (): Promise<void> => {
     try {
@@ -26,6 +28,7 @@ function NodeJSMetrics (): React.ReactElement {
         const data = await getApiMetricsPod(runtimePid)
         setAllData(data)
         setError(undefined)
+        setHasKafkaData(getKafkaType(data.dataKafka))
       }
     } catch (error) {
       setError(error)
@@ -127,6 +130,46 @@ function NodeJSMetrics (): React.ReactElement {
               unit: REQ_UNIT_METRICS
             }]}
           />
+          {hasKafkaData &&
+            <NodeJSMetric
+              title='Kafka'
+              metricURL='kafka'
+              dataValues={allData.dataKafka}
+              initialLoading={initialLoading}
+              unit={`(${KAFKA_UNIT_METRICS})`}
+              options={[
+                {
+                  label: 'Producers',
+                  internalKey: 'producers',
+                  unit: KAFKA_UNIT_METRICS
+                },
+                {
+                  label: 'Consumers',
+                  internalKey: 'consumers',
+                  unit: KAFKA_UNIT_METRICS
+                },
+                {
+                  label: 'Topics',
+                  internalKey: 'consumersTopics',
+                  unit: KAFKA_UNIT_METRICS
+                },
+                {
+                  label: 'Streams',
+                  internalKey: 'consumersStreams',
+                  unit: KAFKA_UNIT_METRICS
+                },
+                {
+                  label: 'Flight',
+                  internalKey: 'hooksMessagesInFlight',
+                  unit: KAFKA_UNIT_METRICS
+                },
+                {
+                  label: 'DLQ',
+                  internalKey: 'hooksDlqMessagesTotal',
+                  unit: KAFKA_UNIT_METRICS
+                }
+              ]}
+            />}
         </div>
       </div>
     </BorderedBox>

--- a/web/frontend/src/components/metrics/MetricChart.tsx
+++ b/web/frontend/src/components/metrics/MetricChart.tsx
@@ -7,6 +7,7 @@ import colorSetMem from './memory.module.css'
 import colorSetCpu from './cpu.module.css'
 import colorSetReq from './req.module.css'
 import colorSetLatency from './latency.module.css'
+import colorSetKafka from './kafka.module.css'
 import { xMargin, yMargin } from './chart_constants'
 import { getTicks } from './utils'
 import { POSITION_ABSOLUTE, POSITION_FIXED } from '../../ui-constants'
@@ -64,6 +65,9 @@ export const getMetricColor = (metricType: MetricType) => {
       break
     case 'latency':
       colorStyles = colorSetLatency
+      break
+    case 'kafka':
+      colorStyles = colorSetKafka
       break
     default:
       throw new Error(`Unhandled metric type: ${metricType}`)

--- a/web/frontend/src/components/metrics/kafka.module.css
+++ b/web/frontend/src/components/metrics/kafka.module.css
@@ -1,0 +1,53 @@
+.color-0 {
+  stroke: #C61BE2;  
+  color: #C61BE2;
+}
+
+.color-1 {
+  stroke: #2588E4;
+  color: #2588E4;
+}
+
+.color-2 {
+  stroke: #5A3CFF;
+  color: #5A3CFF;
+}
+
+.color-3 {
+  stroke: #FA6221;  
+  color: #FA6221;
+}
+
+.color-4 {
+  stroke: #FEB928;
+  color: #FEB928;
+}
+
+.color-5 {
+  stroke: #44FFEC;  
+  color: #44FFEC;
+}
+
+.background-color-0 {
+  background: #C61BE2;
+}
+
+.background-color-1 {
+  background: #2588E4;
+}
+
+.background-color-2 {
+  background: #5A3CFF;
+}
+
+.background-color-3 {
+  background: #FA6221;  
+}
+
+.background-color-4 {
+  background: #FEB928;
+}
+
+.background-color-5 {
+  background: #44FFEC;
+}

--- a/web/frontend/src/ui-constants.ts
+++ b/web/frontend/src/ui-constants.ts
@@ -21,6 +21,7 @@ export const MEMORY_UNIT_METRICS = 'MB'
 export const LATENCY_UNIT_METRICS = 'ms'
 export const CPU_UNIT_METRICS = '%'
 export const REQ_UNIT_METRICS = '#'
+export const KAFKA_UNIT_METRICS = '#'
 
 export const POSITION_ABSOLUTE = 'absolute'
 export const POSITION_FIXED = 'fixed'

--- a/web/frontend/src/utilities/getters.ts
+++ b/web/frontend/src/utilities/getters.ts
@@ -1,3 +1,4 @@
+import { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
 import { ServiceData } from 'src/types'
 
 export const getServiceSelected = (service: ServiceData): boolean => 'selected' in service ? !!service.selected : false
@@ -5,3 +6,15 @@ export const getServiceSelected = (service: ServiceData): boolean => 'selected' 
 export const getServiceWorkers = (service: ServiceData): number => 'workers' in service ? (service.workers ? service.workers : 0) : 0
 
 export const getServiceEntrypoint = (service: ServiceData): boolean => 'entrypoint' in service ? service.entrypoint : false
+
+// FIXME: remove this manual check once the following issue has been done, and we can get the service type directly (https://github.com/platformatic/platformatic/issues/4130)
+export const getKafkaType = (kafkaData: GetRuntimesPidMetricsResponseOK['dataKafka']): boolean => {
+  for (const kafkaMetrics of kafkaData) {
+    for (const value of Object.values(kafkaMetrics)) {
+      if (typeof value === 'number' && value > 0) {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/web/frontend/test/utilities/getters.test.ts
+++ b/web/frontend/test/utilities/getters.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { getServiceSelected, getServiceWorkers, getServiceEntrypoint } from '../../src/utilities/getters'
+import { getServiceSelected, getServiceWorkers, getServiceEntrypoint, getKafkaType } from '../../src/utilities/getters'
 import { ServiceData } from '../../src/types'
 
 describe('getServiceSelected', () => {
@@ -155,5 +155,69 @@ describe('getServiceEntrypoint', () => {
   test('should work when service has entrypoint along with other properties', () => {
     const service = { selected: true, workers: 10, entrypoint: true } as ServiceData
     expect(getServiceEntrypoint(service)).toBe(true)
+  })
+})
+
+describe('getKafkaType', () => {
+  test('should return false when there are no positive values', () => {
+    expect(getKafkaType([{
+      date: new Date().toISOString(),
+      producers: 0,
+      producedMessages: 0,
+      consumers: 0,
+      consumersStreams: 0,
+      consumersTopics: 0,
+      consumedMessages: 0,
+      hooksMessagesInFlight: 0,
+      hooksDlqMessagesTotal: 0
+    }])).toBe(false)
+  })
+
+  test('should return true when there is at least a positive value', () => {
+    expect(getKafkaType([{
+      date: new Date().toISOString(),
+      producers: 0,
+      producedMessages: 0,
+      consumers: 0,
+      consumersStreams: 0,
+      consumersTopics: 0,
+      consumedMessages: 0,
+      hooksMessagesInFlight: 0,
+      hooksDlqMessagesTotal: 0
+    }, {
+      date: new Date().toISOString(),
+      producers: 0,
+      producedMessages: 0,
+      consumers: 0,
+      consumersStreams: 1,
+      consumersTopics: 0,
+      consumedMessages: 0,
+      hooksMessagesInFlight: 0,
+      hooksDlqMessagesTotal: 0
+    }])).toBe(true)
+  })
+
+  test('should return true when there are all positive values', () => {
+    expect(getKafkaType([{
+      date: new Date().toISOString(),
+      producers: 2,
+      producedMessages: 2,
+      consumers: 2,
+      consumersStreams: 3,
+      consumersTopics: 3,
+      consumedMessages: 3,
+      hooksMessagesInFlight: 5,
+      hooksDlqMessagesTotal: 5
+    }, {
+      date: new Date().toISOString(),
+      producers: 4,
+      producedMessages: 4,
+      consumers: 4,
+      consumersStreams: 1,
+      consumersTopics: 7,
+      consumedMessages: 7,
+      hooksMessagesInFlight: 7,
+      hooksDlqMessagesTotal: 10
+    }])).toBe(true)
   })
 })


### PR DESCRIPTION
For now, we have a manual check to detect if a service runs Kafka (or not). Once [this](https://github.com/platformatic/platformatic/issues/4130) will be done, we'll be able to remove it.

QA done ✅ 
<img width="760" height="653" alt="Screenshot 2025-07-16 at 19 14 28" src="https://github.com/user-attachments/assets/9c5fb6ee-ffc6-4667-9e33-935128b0c9e9" />
<img width="749" height="647" alt="Screenshot 2025-07-16 at 19 14 22" src="https://github.com/user-attachments/assets/aec610fd-5631-4305-b7c9-3bfb51159fcc" />

https://github.com/user-attachments/assets/f62b29ac-427a-4e86-a427-e667779a538d

