### PR TITLE
feat(frontend): get kafka type differently

### DIFF
--- a/web/frontend/src/components/metrics/ServicesMetrics.tsx
+++ b/web/frontend/src/components/metrics/ServicesMetrics.tsx
@@ -15,7 +15,7 @@ import colorSetKafka from './kafka.module.css'
 import colorSetUndici from './undici.module.css'
 import colorSetWs from './ws.module.css'
 import NodeJSMetric, { generateLegend } from '../application/NodeJSMetric'
-import { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
+import { GetRuntimesPidMetricsResponseOK, GetRuntimesPidServicesResponseOK } from 'src/client/backend-types'
 import ErrorComponent from '../errors/ErrorComponent'
 import { ServiceData } from 'src/types'
 import { getEmptyMetrics } from '../../utilities/metrics'
@@ -24,6 +24,7 @@ import { getThreadName, ThreadIndex } from '../../utilities/threads'
 
 interface ServicesMetricsProps {
   service: ServiceData;
+  services: GetRuntimesPidServicesResponseOK['services'];
   threadIndex?: ThreadIndex;
   showAggregatedMetrics: boolean;
 }
@@ -41,6 +42,7 @@ const mapColor: Record<KeyMetric, { [key: string]: string }> = {
 function ServicesMetrics ({
   threadIndex,
   service: { id: serviceId },
+  services,
   showAggregatedMetrics
 }: ServicesMetricsProps): React.ReactElement {
   const threadName = threadIndex ? getThreadName(threadIndex) : ''
@@ -49,7 +51,6 @@ function ServicesMetrics ({
   const [serviceData, setServiceData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
   const [allData, setAllData] = useState<GetRuntimesPidMetricsResponseOK>(getEmptyMetrics())
   const { runtimePid } = useAdminStore()
-  const [hasKafkaData, setHasKafkaData] = useState(false)
 
   const getData = async (): Promise<void> => {
     try {
@@ -59,7 +60,6 @@ function ServicesMetrics ({
         setAllData(runtimeData)
         setServiceData(serviceData)
         setError(undefined)
-        setHasKafkaData(getKafkaType(serviceData.dataKafka))
       }
     } catch (error) {
       setError(error)
@@ -78,7 +78,7 @@ function ServicesMetrics ({
   return (
     <div className={`${styles.container} ${styles.content} ${commonStyles.smallFlexBlock} ${commonStyles.fullWidth} ${styles.flexGrow}`}>
       {KEYS_METRICS.map(key => (
-        (key !== 'dataKafka' || (key === 'dataKafka' && hasKafkaData)) &&
+        (key !== 'dataKafka' || (key === 'dataKafka' && getKafkaType(services))) &&
           <div key={key} className={`${commonStyles.tinyFlexBlock} ${commonStyles.fullWidth}`}>
             <div className={`${commonStyles.smallFlexRow} ${commonStyles.fullWidth}`}>
               <BorderedBox color={TRANSPARENT} backgroundColor={RICH_BLACK} classes={styles.boxMetricContainer}>

--- a/web/frontend/src/components/services/ServicesCharts.tsx
+++ b/web/frontend/src/components/services/ServicesCharts.tsx
@@ -87,6 +87,7 @@ const ServicesCharts: React.FC = () => {
             <ServicesMetrics
               threadIndex={threadIndex}
               service={serviceSelected}
+              services={services}
               showAggregatedMetrics={showAggregatedMetrics}
             />
           </div>

--- a/web/frontend/src/utilities/getters.ts
+++ b/web/frontend/src/utilities/getters.ts
@@ -1,4 +1,4 @@
-import { GetRuntimesPidMetricsResponseOK } from 'src/client/backend-types'
+import { GetRuntimesPidServicesResponseOK } from 'src/client/backend-types'
 import { ServiceData } from 'src/types'
 
 export const getServiceSelected = (service: ServiceData): boolean => 'selected' in service ? !!service.selected : false
@@ -9,14 +9,4 @@ export const getServiceEntrypoint = (service: ServiceData): boolean => 'entrypoi
 
 export const getOptionMetricsLabel = (input: { label: string }[]) => input.map(({ label }) => label)
 
-// FIXME: remove this manual check once the following issue has been done, and we can get the service type directly (https://github.com/platformatic/platformatic/issues/4130)
-export const getKafkaType = (kafkaData: GetRuntimesPidMetricsResponseOK['dataKafka']): boolean => {
-  for (const kafkaMetrics of kafkaData) {
-    for (const value of Object.values(kafkaMetrics)) {
-      if (typeof value === 'number' && value > 0) {
-        return true
-      }
-    }
-  }
-  return false
-}
+export const getKafkaType = (services: GetRuntimesPidServicesResponseOK['services']): boolean => services.some(service => 'type' in service && service.type === 'kafka-hooks')

--- a/web/frontend/test/utilities/getters.test.ts
+++ b/web/frontend/test/utilities/getters.test.ts
@@ -170,65 +170,15 @@ describe('getOptionMetricsLabel', () => {
 })
 
 describe('getKafkaType', () => {
-  test('should return false when there are no positive values', () =>
-    expect(getKafkaType([{
-      date: new Date().toISOString(),
-      producers: 0,
-      producedMessages: 0,
-      consumers: 0,
-      consumersStreams: 0,
-      consumersTopics: 0,
-      consumedMessages: 0,
-      hooksMessagesInFlight: 0,
-      hooksDlqMessagesTotal: 0
-    }])).toBe(false)
+  test('should return false when there are no kafka-hooks values', () =>
+    expect(getKafkaType([{ type: 'foo' }, { type: 'bar' }, { type: 'baz' }])).toBe(false)
   )
 
   test('should return true when there is at least a positive value', () =>
-    expect(getKafkaType([{
-      date: new Date().toISOString(),
-      producers: 0,
-      producedMessages: 0,
-      consumers: 0,
-      consumersStreams: 0,
-      consumersTopics: 0,
-      consumedMessages: 0,
-      hooksMessagesInFlight: 0,
-      hooksDlqMessagesTotal: 0
-    }, {
-      date: new Date().toISOString(),
-      producers: 0,
-      producedMessages: 0,
-      consumers: 0,
-      consumersStreams: 1,
-      consumersTopics: 0,
-      consumedMessages: 0,
-      hooksMessagesInFlight: 0,
-      hooksDlqMessagesTotal: 0
-    }])).toBe(true)
+    expect(getKafkaType([{ type: 'foo' }, { type: 'kafka-hooks' }, { type: 'baz' }])).toBe(true)
   )
 
-  test('should return true when there are all positive values', () =>
-    expect(getKafkaType([{
-      date: new Date().toISOString(),
-      producers: 2,
-      producedMessages: 2,
-      consumers: 2,
-      consumersStreams: 3,
-      consumersTopics: 3,
-      consumedMessages: 3,
-      hooksMessagesInFlight: 5,
-      hooksDlqMessagesTotal: 5
-    }, {
-      date: new Date().toISOString(),
-      producers: 4,
-      producedMessages: 4,
-      consumers: 4,
-      consumersStreams: 1,
-      consumersTopics: 7,
-      consumedMessages: 7,
-      hooksMessagesInFlight: 7,
-      hooksDlqMessagesTotal: 10
-    }])).toBe(true)
+  test('should return false when the array is empty', () =>
+    expect(getKafkaType([])).toBe(false)
   )
 })


### PR DESCRIPTION
Since [this](https://github.com/platformatic/platformatic/issues/4130) has been done, we can now access the kafka type in a simpler way